### PR TITLE
Do not use purgeCSS on custom SASS

### DIFF
--- a/layouts/partials/head/css.html
+++ b/layouts/partials/head/css.html
@@ -25,10 +25,14 @@
 {{ $css := $style }}
 
 {{ if or (strings.HasSuffix $style.Name "sass") (strings.HasSuffix $style.Name "scss")}}
-{{ $css = $css | toCSS $cssOpts }}
+{{ $customCSSopt := (dict "targetPath" "css/main.css" "outputStyle" "compressed" "enableSourceMap" false) }}
+{{ if site.IsServer }}
+{{ $customCSSopt = (dict "targetPath" "css/main.css" "outputStyle" "expanded" "enableSourceMap" true) }}
+{{ end }}
+{{ $css = $css | toCSS $customCSSopt }}
 {{ end }}
 
-{{ $css = $css | postCSS $postCSSOpts | minify | fingerprint "md5" | resources.PostProcess }}
+{{ $css = $css | minify | fingerprint "md5" | resources.PostProcess }}
 <link rel="stylesheet" href="{{ $css.Permalink }}" crossorigin="anonymous" media="screen"
 	integrity="{{ $css.Data.Integrity }}">
 {{ end }}


### PR DESCRIPTION
This code prevents custom CSS classes (that you could write to be applied on javascript-generated components) from being removed by purgecss