### PR TITLE
Unsupported hash algorithm in the integrity attribute: “md5”

### DIFF
--- a/layouts/partials/head/css.html
+++ b/layouts/partials/head/css.html
@@ -6,7 +6,7 @@
 {{ $bundle := $bundleRaw | toCSS $cssOpts | postCSS $postCSSOpts }}
 <link rel="stylesheet" href="{{ $bundle.Permalink }}" media="screen">
 {{ else }}
-{{ $bundle := $bundleRaw | toCSS $cssOpts | postCSS $postCSSOpts | minify | fingerprint "md5" | resources.PostProcess }}
+{{ $bundle := $bundleRaw | toCSS $cssOpts | postCSS $postCSSOpts | minify | fingerprint "sha256" | resources.PostProcess }}
 <link rel="stylesheet" href="{{ $bundle.Permalink }}" crossorigin="anonymous" media="screen"
 	integrity="{{ $bundle.Data.Integrity }}">
 {{ end }}
@@ -14,7 +14,7 @@
 {{/* Blog post page syntax highlighting */}}
 {{ if eq .Type "blog" }}
 {{ $syntax := resources.Get "css/syntax.css" }}
-{{ $syntax = $syntax | resources.Minify | fingerprint "md5" }}
+{{ $syntax = $syntax | resources.Minify | fingerprint "sha256" }}
 <link rel="stylesheet" href="{{ $syntax.Permalink }}" crossorigin="anonymous"
 	integrity="{{ $syntax.Data.Integrity }}" media="screen">
 {{ end }}
@@ -32,7 +32,7 @@
 {{ $css = $css | toCSS $customCSSopt }}
 {{ end }}
 
-{{ $css = $css | minify | fingerprint "md5" | resources.PostProcess }}
+{{ $css = $css | minify | fingerprint "sha256" | resources.PostProcess }}
 <link rel="stylesheet" href="{{ $css.Permalink }}" crossorigin="anonymous" media="screen"
 	integrity="{{ $css.Data.Integrity }}">
 {{ end }}

--- a/layouts/partials/head/js.html
+++ b/layouts/partials/head/js.html
@@ -14,7 +14,7 @@
 
 {{ if gt (len $js_bundle) 0 }}
 
-{{ $js_bundle = $js_bundle | resources.Concat "js/pico.min.js" | fingerprint "md5" }}
+{{ $js_bundle = $js_bundle | resources.Concat "js/pico.min.js" | fingerprint "sha256" }}
 <script src="{{ $js_bundle.Permalink }}" intergrity="{{ $js_bundle.Data.Integrity }}" crossorigin="anonymous"></script>
 
 {{ end }}


### PR DESCRIPTION
Fixed warning by updating md5 hashes to sha256 hashes